### PR TITLE
Fix slack default connector issue

### DIFF
--- a/composio/cli/add.py
+++ b/composio/cli/add.py
@@ -174,6 +174,7 @@ def add_integration(
     else:
         connection = entity.initiate_connection(
             app_name=name,
+            auth_mode=auth_modes[0],
             redirect_url=get_web_url(path="redirect"),
             integration=integration,
         )

--- a/composio/cli/add.py
+++ b/composio/cli/add.py
@@ -174,7 +174,7 @@ def add_integration(
     else:
         connection = entity.initiate_connection(
             app_name=name,
-            auth_mode=auth_modes[0],
+            auth_mode=auth_modes[0] if auth_modes and len(auth_modes) > 0 else None,
             redirect_url=get_web_url(path="redirect"),
             integration=integration,
         )

--- a/composio/client/__init__.py
+++ b/composio/client/__init__.py
@@ -647,7 +647,6 @@ class Actions(Collection[ActionModel]):
                 )
             )
             return [self.model(**action) for action in response.json().get("items")]
-        
 
         queries: t.Dict[str, str] = {}
         if use_case is not None and use_case != "":

--- a/composio/client/__init__.py
+++ b/composio/client/__init__.py
@@ -638,6 +638,7 @@ class Actions(Collection[ActionModel]):
                 "to be used in production. Check out https://docs.composio.dev/sdk/python/actions for more information.",
                 UserWarning,
             )
+            tags = ["important"]
 
         if len(actions) == 0 and len(apps) == 0 and len(tags) == 0 and allow_all:
             response = self._raise_if_required(
@@ -646,6 +647,7 @@ class Actions(Collection[ActionModel]):
                 )
             )
             return [self.model(**action) for action in response.json().get("items")]
+        
 
         queries: t.Dict[str, str] = {}
         if use_case is not None and use_case != "":

--- a/composio/client/__init__.py
+++ b/composio/client/__init__.py
@@ -976,9 +976,10 @@ class Entity:
         if isinstance(app_name, App):
             app_name = app_name.value
 
+        app = self.client.apps.get(name=app_name)
         if auth_mode is None:
             integration = integration or self.client.integrations.create(
-                app_id=app_name,
+                app_id=app.appId,
                 use_composio_auth=True,
             )
             return self.client.connected_accounts.initiate(
@@ -987,7 +988,6 @@ class Entity:
                 redirect_url=redirect_url,
             )
 
-        app = self.client.apps.get(name=app_name)
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         integration = integration or self.client.integrations.create(
             app_id=app.appId,

--- a/composio/client/__init__.py
+++ b/composio/client/__init__.py
@@ -978,6 +978,8 @@ class Entity:
             app_name = app_name.value
 
         app = self.client.apps.get(name=app_name)
+        if not app:
+            raise ComposioClientError(f"App with name {app_name} not found")
         if auth_mode is None:
             integration = integration or self.client.integrations.create(
                 app_id=app.appId,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `auth_mode` parameter to connection initiation in `add.py`.
- Fixed app details retrieval and updated integration creation to use `app.appId` in `__init__.py`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add.py</strong><dd><code>Add `auth_mode` parameter to connection initiation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/cli/add.py

- Added `auth_mode` parameter when initiating a connection.



</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/62/files#diff-7cd5ff3775517d5c193b445990cb43a4fd785eaa3ce17f23dfe48bba9d7b5b6f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Fix app details retrieval and integration creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/client/__init__.py

<li>Added retrieval of app details before checking <code>auth_mode</code>.<br> <li> Updated integration creation to use <code>app.appId</code> instead of <code>app_name</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/62/files#diff-17f4a7383ae2819192cd4556b82eeb2389ca39bd3f6919573c0d8c2edd61e38f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

