### PR TITLE
Entity id argument usage on plugins

### DIFF
--- a/plugins/autogen/composio_autogen/toolset.py
+++ b/plugins/autogen/composio_autogen/toolset.py
@@ -49,6 +49,7 @@ class ComposioToolSet(BaseComposioToolSet):
         caller: t.Optional[ConversableAgent] = None,
         executor: t.Optional[ConversableAgent] = None,
         tags: t.Optional[t.Sequence[Tag]] = None,
+        entity_id: t.Optional[str] = None,
     ) -> None:
         """
         Register tools to the proxy agents.
@@ -57,6 +58,7 @@ class ComposioToolSet(BaseComposioToolSet):
         :param caller: Caller agent.
         :param executor: Executor agent.
         :param tags: Filter by the list of given Tags.
+        :param entity_id: Entity ID to use for executing function calls.
         """
         if isinstance(tools, App):
             tools = [tools]
@@ -79,6 +81,7 @@ class ComposioToolSet(BaseComposioToolSet):
                 ),
                 caller=caller,
                 executor=executor,
+                entity_id=entity_id or self.entity_id,
             )
 
     def register_actions(
@@ -86,6 +89,7 @@ class ComposioToolSet(BaseComposioToolSet):
         actions: t.Sequence[Action],
         caller: t.Optional[ConversableAgent] = None,
         executor: t.Optional[ConversableAgent] = None,
+        entity_id: t.Optional[str] = None,
     ):
         """
         Register tools to the proxy agents.
@@ -93,6 +97,7 @@ class ComposioToolSet(BaseComposioToolSet):
         :param actions: List of tools to register.
         :param caller: Caller agent.
         :param executor: Executor agent.
+        :param entity_id: Entity ID to use for executing function calls.
         """
 
         caller = caller or self.caller
@@ -113,6 +118,7 @@ class ComposioToolSet(BaseComposioToolSet):
                 ),
                 caller=caller,
                 executor=executor,
+                entity_id=entity_id or self.entity_id,
             )
 
     def _process_function_name_for_registration(
@@ -134,7 +140,9 @@ class ComposioToolSet(BaseComposioToolSet):
         schema: t.Dict,
         caller: ConversableAgent,
         executor: ConversableAgent,
-    ):
+        entity_id: t.Optional[str] = None,
+    ) -> None:
+        """Register action schema to autogen registry."""
         name = schema["name"]
         appName = schema["appName"]
         description = schema["description"]
@@ -147,7 +155,7 @@ class ComposioToolSet(BaseComposioToolSet):
                     name=name,
                 ),
                 params=kwargs,
-                entity_id=self.entity_id,
+                entity_id=entity_id or self.entity_id,
             )
 
         function = types.FunctionType(

--- a/plugins/claude/composio_claude/toolset.py
+++ b/plugins/claude/composio_claude/toolset.py
@@ -136,42 +136,42 @@ class ComposioToolset(ComposioToolSet):
     def execute_tool_call(
         self,
         tool_call: ToolUseBlock,
-        entity_id: str = DEFAULT_ENTITY_ID,
+        entity_id: t.Optional[str] = None,
     ) -> t.Dict:
         """
         Execute a tool call.
 
         :param tool_call: Tool call metadata.
-        :param entity_id: Entity ID.
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Object containing output data from the tool call.
         """
         return self.execute_action(
             action=Action.from_action(name=tool_call.name),
             params=t.cast(t.Dict, tool_call.input),
-            entity_id=entity_id,
+            entity_id=entity_id or self.entity_id,
         )
 
     def handle_tool_calls(
         self,
         llm_response: ToolsBetaMessage,
-        entity_id: str = DEFAULT_ENTITY_ID,
+        entity_id: t.Optional[str] = None,
     ) -> t.List[t.Dict]:
         """
         Handle tool calls from OpenAI chat completion object.
 
         :param response: Chat completion object from
                         openai.OpenAI.chat.completions.create function call
-        :param entity_id: Entity ID.
+        :param entity_id: Entity ID to use for executing function calls.
         :return: A list of output objects from the function calls.
         """
-        entity_id = self.validate_entity_id(entity_id)
+        entity_id = self.validate_entity_id(entity_id or self.entity_id)
         outputs = []
         for content in llm_response.content:
             if isinstance(content, ToolUseBlock):
                 outputs.append(
                     self.execute_tool_call(
                         tool_call=content,
-                        entity_id=entity_id,
+                        entity_id=entity_id or self.entity_id,
                     )
                 )
         return outputs

--- a/plugins/griptape/composio_griptape/toolset.py
+++ b/plugins/griptape/composio_griptape/toolset.py
@@ -63,7 +63,11 @@ class ComposioToolSet(BaseComposioToolSet):
             entity_id=entity_id,
         )
 
-    def _wrap_tool(self, schema: t.Dict) -> t.Type[BaseTool]:
+    def _wrap_tool(
+        self,
+        schema: t.Dict,
+        entity_id: t.Optional[str] = None,
+    ) -> BaseTool:
         """Wrap Composio tool as GripTape `BaseTool` object"""
         app = schema["appName"]
         name = schema["name"]
@@ -90,11 +94,11 @@ class ComposioToolSet(BaseComposioToolSet):
             schema_dict[schema_key] = schema_dtype
 
         def _execute_task(params: t.Dict) -> t.Dict:
-            """Auxialiry method for executing task."""
+            """Placeholder method for executing task."""
             return self.execute_action(
                 action=Action.from_app_and_action(app=app, name=name),
                 params=params,
-                entity_id=self.entity_id,
+                entity_id=entity_id or self.entity_id,
             )
 
         class GripTapeTool(BaseTool):
@@ -124,18 +128,27 @@ class ComposioToolSet(BaseComposioToolSet):
                 }
 
         name = "".join(map(lambda x: x.title(), name.split("_"))) + "Client"
-        return type(name, (GripTapeTool,), {})
+        cls = type(name, (GripTapeTool,), {})
+        return cls()
 
-    def get_actions(self, actions: t.Sequence[Action]) -> t.List[BaseTool]:
+    def get_actions(
+        self,
+        actions: t.Sequence[Action],
+        entity_id: t.Optional[str] = None,
+    ) -> t.List[BaseTool]:
         """
         Get composio tools wrapped as GripTape `BaseTool` type objects.
 
         :param actions: List of actions to wrap
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Composio tools wrapped as `BaseTool` objects
         """
 
         return [
-            self._wrap_tool(schema=tool.model_dump(exclude_none=True))()
+            self._wrap_tool(
+                schema=tool.model_dump(exclude_none=True),
+                entity_id=entity_id,
+            )
             for tool in self.client.actions.get(actions=actions)
         ]
 
@@ -143,16 +156,21 @@ class ComposioToolSet(BaseComposioToolSet):
         self,
         apps: t.Sequence[App],
         tags: t.Optional[t.List[t.Union[str, Tag]]] = None,
+        entity_id: t.Optional[str] = None,
     ) -> t.List[BaseTool]:
         """
         Get composio tools wrapped as GripTape `BaseTool` type objects.
 
         :param apps: List of apps to wrap
         :param tags: Filter the apps by given tags
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Composio tools wrapped as `BaseTool` objects
         """
 
         return [
-            self._wrap_tool(schema=tool.model_dump(exclude_none=True))()
+            self._wrap_tool(
+                schema=tool.model_dump(exclude_none=True),
+                entity_id=entity_id,
+            )
             for tool in self.client.actions.get(apps=apps, tags=tags)
         ]

--- a/plugins/julep/composio_julep/toolset.py
+++ b/plugins/julep/composio_julep/toolset.py
@@ -36,17 +36,17 @@ class ComposioToolSet(BaseComposioToolSet):
     def handle_tool_calls(
         self,
         response: ChatResponse,
-        entity_id: str = "default",
+        entity_id: str = DEFAULT_ENTITY_ID,
     ) -> t.List[t.Dict]:
         """
         Handle tool calls from Julep chat client object.
 
         :param response: Chat completion object from
                         julep.Client.sessions.chat function call
-        :param entity_id: Entity ID.
+        :param entity_id: Entity ID to use for executing function calls.
         :return: A list of output objects from the function calls.
         """
-        entity_id = self.validate_entity_id(entity_id)
+        entity_id = self.validate_entity_id(entity_id or self.entity_id)
         outputs = []
 
         for _responses in response.response:
@@ -57,7 +57,7 @@ class ComposioToolSet(BaseComposioToolSet):
                         self.execute_action(
                             action=Action.from_action(name=function["name"]),
                             params=json.loads(function["arguments"]),
-                            entity_id=self.entity_id,
+                            entity_id=entity_id or self.entity_id,
                         )
                     )
                 except json.JSONDecodeError:

--- a/plugins/langchain/composio_langchain/toolset.py
+++ b/plugins/langchain/composio_langchain/toolset.py
@@ -75,7 +75,11 @@ class ComposioToolSet(BaseComposioToolSet):
             entity_id=entity_id,
         )
 
-    def _wrap_tool(self, schema: t.Dict[str, t.Any]) -> StructuredTool:
+    def _wrap_tool(
+        self,
+        schema: t.Dict[str, t.Any],
+        entity_id: t.Optional[str] = None,
+    ) -> StructuredTool:
         """Wraps composio tool as Langchain StructuredTool object."""
         app = schema["appName"]
         action = schema["name"]
@@ -89,6 +93,7 @@ class ComposioToolSet(BaseComposioToolSet):
                     name=action,
                 ),
                 params=kwargs,
+                entity_id=entity_id or self.entity_id,
             )
 
         parameters = json_schema_to_model(
@@ -114,16 +119,24 @@ class ComposioToolSet(BaseComposioToolSet):
             func=action_func,
         )
 
-    def get_actions(self, actions: t.Sequence[Action]) -> t.Sequence[StructuredTool]:
+    def get_actions(
+        self,
+        actions: t.Sequence[Action],
+        entity_id: t.Optional[str] = None,
+    ) -> t.Sequence[StructuredTool]:
         """
         Get composio tools wrapped as Langchain StructuredTool objects.
 
         :param actions: List of actions to wrap
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Composio tools wrapped as `StructuredTool` objects
         """
 
         return [
-            self._wrap_tool(schema=tool.model_dump(exclude_none=True))
+            self._wrap_tool(
+                schema=tool.model_dump(exclude_none=True),
+                entity_id=entity_id or self.entity_id,
+            )
             for tool in self.client.actions.get(actions=actions)
         ]
 
@@ -131,16 +144,21 @@ class ComposioToolSet(BaseComposioToolSet):
         self,
         apps: t.Sequence[App],
         tags: t.Optional[t.List[t.Union[str, Tag]]] = None,
+        entity_id: t.Optional[str] = None,
     ) -> t.Sequence[StructuredTool]:
         """
         Get composio tools wrapped as Langchain StructuredTool objects.
 
         :param apps: List of apps to wrap
         :param tags: Filter the apps by given tags
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Composio tools wrapped as `StructuredTool` objects
         """
 
         return [
-            self._wrap_tool(schema=tool.model_dump(exclude_none=True))
+            self._wrap_tool(
+                schema=tool.model_dump(exclude_none=True),
+                entity_id=entity_id or self.entity_id,
+            )
             for tool in self.client.actions.get(apps=apps, tags=tags)
         ]

--- a/plugins/lyzr/composio_lyzr/toolset.py
+++ b/plugins/lyzr/composio_lyzr/toolset.py
@@ -42,7 +42,11 @@ class ComposioToolSet(BaseComposioToolSet):
             entity_id=entity_id,
         )
 
-    def _wrap_tool(self, schema: t.Dict) -> Tool:
+    def _wrap_tool(
+        self,
+        schema: t.Dict,
+        entity_id: t.Optional[str] = None,
+    ) -> Tool:
         """
         Wrap composio tool as Lyzr `Tool` object.
         """
@@ -58,7 +62,7 @@ class ComposioToolSet(BaseComposioToolSet):
                     name=name,
                 ),
                 params=kwargs,
-                entity_id=self.entity_id,
+                entity_id=entity_id or self.entity_id,
             )
 
         action_func = types.FunctionType(
@@ -86,15 +90,23 @@ class ComposioToolSet(BaseComposioToolSet):
             default_params={},
         )
 
-    def get_actions(self, actions: t.Sequence[Action]) -> t.List[Tool]:
+    def get_actions(
+        self,
+        actions: t.Sequence[Action],
+        entity_id: t.Optional[str] = None,
+    ) -> t.List[Tool]:
         """
         Get composio tools wrapped as Lyzr `Tool` objects.
 
         :param actions: List of actions to wrap
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Composio tools wrapped as `Tool` objects
         """
         return [
-            self._wrap_tool(schema=schema.model_dump(exclude_none=True))
+            self._wrap_tool(
+                schema=schema.model_dump(exclude_none=True),
+                entity_id=entity_id or self.entity_id,
+            )
             for schema in self.client.actions.get(actions=actions)
         ]
 
@@ -102,15 +114,20 @@ class ComposioToolSet(BaseComposioToolSet):
         self,
         apps: t.Sequence[App],
         tags: t.Optional[t.List[t.Union[str, Tag]]] = None,
+        entity_id: t.Optional[str] = None,
     ) -> t.Sequence[Tool]:
         """
         Get composio tools wrapped as Lyzr `Tool` objects.
 
         :param apps: List of apps to wrap
         :param tags: Filter the apps by given tags
+        :param entity_id: Entity ID to use for executing function calls.
         :return: Composio tools wrapped as `Tool` objects
         """
         return [
-            self._wrap_tool(schema=schema.model_dump(exclude_none=True))
+            self._wrap_tool(
+                schema=schema.model_dump(exclude_none=True),
+                entity_id=entity_id or self.entity_id,
+            )
             for schema in self.client.actions.get(apps=apps, tags=tags)
         ]

--- a/plugins/openai/composio_openai/toolset.py
+++ b/plugins/openai/composio_openai/toolset.py
@@ -150,35 +150,35 @@ class ComposioToolSet(BaseComposioToolSet):
     def execute_tool_call(
         self,
         tool_call: ChatCompletionMessageToolCall,
-        entity_id: str = DEFAULT_ENTITY_ID,
+        entity_id: t.Optional[str] = None,
     ) -> t.Dict:
         """
         Execute a tool call.
 
         :param tool_call: Tool call metadata.
-        :param entity_id: Entity ID.
+        :param entity_id: Entity ID to use for executing the function call.
         :return: Object containing output data from the tool call.
         """
         return self.execute_action(
             action=Action.from_action(name=tool_call.function.name),
             params=json.loads(tool_call.function.arguments),
-            entity_id=entity_id,
+            entity_id=entity_id or self.entity_id,
         )
 
     def handle_tool_calls(
         self,
         response: ChatCompletion,
-        entity_id: str = DEFAULT_ENTITY_ID,
+        entity_id: t.Optional[str] = None,
     ) -> t.List[t.Dict]:
         """
         Handle tool calls from OpenAI chat completion object.
 
         :param response: Chat completion object from
                         openai.OpenAI.chat.completions.create function call
-        :param entity_id: Entity ID.
+        :param entity_id: Entity ID to use for executing the function call.
         :return: A list of output objects from the function calls.
         """
-        entity_id = self.validate_entity_id(entity_id)
+        entity_id = self.validate_entity_id(entity_id or self.entity_id)
         outputs = []
         if response.choices:
             for choice in response.choices:
@@ -187,12 +187,16 @@ class ComposioToolSet(BaseComposioToolSet):
                         outputs.append(
                             self.execute_tool_call(
                                 tool_call=tool_call,
-                                entity_id=entity_id,
+                                entity_id=entity_id or self.entity_id,
                             )
                         )
         return outputs
 
-    def handle_assistant_tool_calls(self, run: Run) -> t.List:
+    def handle_assistant_tool_calls(
+        self,
+        run: Run,
+        entity_id: t.Optional[str] = None,
+    ) -> t.List:
         """Wait and handle assisant function calls"""
         tool_outputs = []
         for tool_call in t.cast(
@@ -200,7 +204,7 @@ class ComposioToolSet(BaseComposioToolSet):
         ).submit_tool_outputs.tool_calls:
             tool_response = self.execute_tool_call(
                 tool_call=t.cast(ChatCompletionMessageToolCall, tool_call),
-                entity_id=self.entity_id,
+                entity_id=entity_id or self.entity_id,
             )
             tool_output = {
                 "tool_call_id": tool_call.id,
@@ -214,6 +218,7 @@ class ComposioToolSet(BaseComposioToolSet):
         client: Client,
         run: Run,
         thread: Thread,
+        entity_id: t.Optional[str] = None,
     ) -> Run:
         """Wait and handle assisant function calls"""
         thread_object = thread
@@ -222,7 +227,10 @@ class ComposioToolSet(BaseComposioToolSet):
                 run = client.beta.threads.runs.submit_tool_outputs(
                     thread_id=thread_object.id,
                     run_id=run.id,
-                    tool_outputs=self.handle_assistant_tool_calls(run),
+                    tool_outputs=self.handle_assistant_tool_calls(
+                        run=run,
+                        entity_id=entity_id or self.entity_id,
+                    ),
                 )
             else:
                 run = client.beta.threads.runs.retrieve(


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added an optional `entity_id` parameter to various methods across multiple toolsets.
- Updated docstrings to reflect the inclusion of the `entity_id` parameter.
- Modified method calls to utilize the `entity_id` parameter if provided, defaulting to `self.entity_id` otherwise.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Add `entity_id` parameter to toolset methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/autogen/composio_autogen/toolset.py

<li>Added <code>entity_id</code> parameter to multiple methods.<br> <li> Updated docstrings to include <code>entity_id</code> parameter.<br> <li> Modified method calls to use <code>entity_id</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-bdaf2573169d3af6d0330387c4ec55a4d5aadf8ec20a578b34eb1cb9912a67ab">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Make `entity_id` parameter optional in Claude toolset</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/claude/composio_claude/toolset.py

<li>Changed <code>entity_id</code> parameter to be optional in multiple methods.<br> <li> Updated docstrings to reflect the optional nature of <code>entity_id</code>.<br> <li> Modified method calls to use <code>entity_id</code> if provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-8b7c167554866e38057e15be9263bfcaf5154045385060bbf70aec9b66ddf205">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Add optional `entity_id` parameter to Griptape toolset</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/griptape/composio_griptape/toolset.py

<li>Added optional <code>entity_id</code> parameter to methods.<br> <li> Updated docstrings to include <code>entity_id</code>.<br> <li> Modified method calls to use <code>entity_id</code> if provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-d22e852a7fb88007e2e3c210c3dc502e555185c6667456eeece423b224a33d43">+25/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Make `entity_id` parameter optional in Julep toolset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/julep/composio_julep/toolset.py

<li>Changed <code>entity_id</code> parameter to be optional in <code>handle_tool_calls</code>.<br> <li> Updated docstrings to reflect the optional nature of <code>entity_id</code>.<br> <li> Modified method calls to use <code>entity_id</code> if provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-5e35813e07e89229369895782e16a6879384359fb00d460b44ea60fde9c8bcfc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Add optional `entity_id` parameter to Langchain toolset</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/langchain/composio_langchain/toolset.py

<li>Added optional <code>entity_id</code> parameter to methods.<br> <li> Updated docstrings to include <code>entity_id</code>.<br> <li> Modified method calls to use <code>entity_id</code> if provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-63eb290f2eef114f472a450f8578e67832048fa2c8c06279b0dd1cc5380a4f36">+22/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Add optional `entity_id` parameter to Lyzr toolset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/lyzr/composio_lyzr/toolset.py

<li>Added optional <code>entity_id</code> parameter to methods.<br> <li> Updated docstrings to include <code>entity_id</code>.<br> <li> Modified method calls to use <code>entity_id</code> if provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-187c77e269c519b33065230a455b2a4312fb6ffc39220a0f133271a8dd691377">+22/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>toolset.py</strong><dd><code>Make `entity_id` parameter optional in OpenAI toolset</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
plugins/openai/composio_openai/toolset.py

<li>Changed <code>entity_id</code> parameter to be optional in multiple methods.<br> <li> Updated docstrings to reflect the optional nature of <code>entity_id</code>.<br> <li> Modified method calls to use <code>entity_id</code> if provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/70/files#diff-d2891a4954329f254cbb51a3ff4631cac252e69b131a35e73e46633286bd079d">+18/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

