### PR TITLE
chore: version bump to 0.3.3

### DIFF
--- a/plugins/autogen/setup.py
+++ b/plugins/autogen/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_autogen",
-    version="0.3.2",
+    version="0.3.3",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Autogen agent.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_core===0.3.2", "pyautogen>=0.2.19"],
+    install_requires=["composio_core===0.3.3", "pyautogen>=0.2.19"],
     include_package_data=True,
 )

--- a/plugins/claude/setup.py
+++ b/plugins/claude/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_claude",
-    version="0.3.2",
+    version="0.3.3",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Claude LLMs.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_openai===0.3.2", "anthropic>=0.25.7"],
+    install_requires=["composio_openai===0.3.3", "anthropic>=0.25.7"],
     include_package_data=True,
 )

--- a/plugins/crew_ai/setup.py
+++ b/plugins/crew_ai/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_crewai",
-    version="0.3.2",
+    version="0.3.3",
     author="Himanshu",
     author_email="himanshu@composio.dev",
     description="Use Composio to get an array of tools with your CrewAI agent.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_langchain===0.3.2"],
+    install_requires=["composio_langchain===0.3.3"],
     include_package_data=True,
 )

--- a/plugins/griptape/setup.py
+++ b/plugins/griptape/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_griptape",
-    version="0.3.2",
+    version="0.3.3",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Griptape wokflow.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_core===0.3.2", "griptape>=0.24.2"],
+    install_requires=["composio_core===0.3.3", "griptape>=0.24.2"],
     include_package_data=True,
 )

--- a/plugins/julep/setup.py
+++ b/plugins/julep/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_julep",
-    version="0.3.2",
+    version="0.3.3",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Julep wokflow.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_openai===0.3.2", "julep>=0.3.2"],
+    install_requires=["composio_openai===0.3.3", "julep>=0.3.2"],
     include_package_data=True,
 )

--- a/plugins/langchain/setup.py
+++ b/plugins/langchain/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_langchain",
-    version="0.3.2",
+    version="0.3.3",
     author="Karan",
     author_email="karan@composio.dev",
     description="Use Composio to get an array of tools with your LangChain agent.",
@@ -27,7 +27,7 @@ setup(
         "langchain-openai>=0.0.2.post1",
         "pydantic>=2.6.4",
         "langchainhub>=0.1.15",
-        "composio_core===0.3.2",
+        "composio_core===0.3.3",
     ],
     include_package_data=True,
 )

--- a/plugins/lyzr/setup.py
+++ b/plugins/lyzr/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_lyzr",
-    version="0.3.2",
+    version="0.3.3",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Lyzr workflow.",
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "lyzr-automata>=0.1.3",
         "pydantic>=2.6.4",
-        "composio_core===0.3.2",
+        "composio_core===0.3.3",
         "langchain>=0.1.0",
     ],
     include_package_data=True,

--- a/plugins/openai/setup.py
+++ b/plugins/openai/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_openai",
-    version="0.3.2",
+    version="0.3.3",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your OpenAI Function Call.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_core===0.3.2"],
+    install_requires=["composio_core===0.3.3"],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="composio_core",
-    version="0.3.2",
+    version="0.3.3",
     author="Utkarsh",
     author_email="utkarsh@composio.dev",
     description="Core package to act as a bridge between composio platform and other services.",


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 12606a6e696258337673e9da7c62e0fcc5cf36d8  | 
|--------|--------|

### Summary:
Version bump to 0.3.3 for `composio_core` and various plugins, along with dependency updates to maintain compatibility.

**Key points**:
- Bumped version of `composio_core` and various plugins (`autogen`, `claude`, `crew_ai`, `griptape`, `julep`, `langchain`, `lyzr`, `openai`) to `0.3.3`.
- Updated dependencies in `install_requires` to use the new version `0.3.3` where applicable.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
