### PR TITLE
fix: make app name in composio add case-insensitive

### DIFF
--- a/composio/cli/add.py
+++ b/composio/cli/add.py
@@ -54,7 +54,7 @@ def _add(
     """Add a new integration."""
     try:
         add_integration(
-            name=name,
+            name=name.lower().strip(),
             context=context,
             entity_id=entity_id,
             integration_id=integration_id,

--- a/plugins/autogen/setup.py
+++ b/plugins/autogen/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_autogen",
-    version="0.3.7",
+    version="0.3.8",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Autogen agent.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_core===0.3.7", "pyautogen>=0.2.19"],
+    install_requires=["composio_core===0.3.8", "pyautogen>=0.2.19"],
     include_package_data=True,
 )

--- a/plugins/claude/setup.py
+++ b/plugins/claude/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_claude",
-    version="0.3.7",
+    version="0.3.8",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Claude LLMs.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_openai===0.3.7", "anthropic>=0.25.7"],
+    install_requires=["composio_openai===0.3.8", "anthropic>=0.25.7"],
     include_package_data=True,
 )

--- a/plugins/crew_ai/setup.py
+++ b/plugins/crew_ai/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_crewai",
-    version="0.3.7",
+    version="0.3.8",
     author="Himanshu",
     author_email="himanshu@composio.dev",
     description="Use Composio to get an array of tools with your CrewAI agent.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_langchain===0.3.7"],
+    install_requires=["composio_langchain===0.3.8"],
     include_package_data=True,
 )

--- a/plugins/griptape/setup.py
+++ b/plugins/griptape/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_griptape",
-    version="0.3.7",
+    version="0.3.8",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Griptape wokflow.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_core===0.3.7", "griptape>=0.24.2"],
+    install_requires=["composio_core===0.3.8", "griptape>=0.24.2"],
     include_package_data=True,
 )

--- a/plugins/julep/setup.py
+++ b/plugins/julep/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_julep",
-    version="0.3.7",
+    version="0.3.8",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Julep wokflow.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_openai===0.3.7", "julep>=0.3.2"],
+    install_requires=["composio_openai===0.3.8", "julep>=0.3.2"],
     include_package_data=True,
 )

--- a/plugins/langchain/setup.py
+++ b/plugins/langchain/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_langchain",
-    version="0.3.7",
+    version="0.3.8",
     author="Karan",
     author_email="karan@composio.dev",
     description="Use Composio to get an array of tools with your LangChain agent.",
@@ -27,7 +27,7 @@ setup(
         "langchain-openai>=0.0.2.post1",
         "pydantic>=2.6.4",
         "langchainhub>=0.1.15",
-        "composio_core===0.3.7",
+        "composio_core===0.3.8",
     ],
     include_package_data=True,
 )

--- a/plugins/lyzr/setup.py
+++ b/plugins/lyzr/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_lyzr",
-    version="0.3.7",
+    version="0.3.8",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your Lyzr workflow.",
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "lyzr-automata>=0.1.3",
         "pydantic>=2.6.4",
-        "composio_core===0.3.7",
+        "composio_core===0.3.8",
         "langchain>=0.1.0",
     ],
     include_package_data=True,

--- a/plugins/openai/setup.py
+++ b/plugins/openai/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name="composio_openai",
-    version="0.3.7",
+    version="0.3.8",
     author="Sawradip",
     author_email="sawradip@composio.dev",
     description="Use Composio to get an array of tools with your OpenAI Function Call.",
@@ -22,6 +22,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.9,<4",
-    install_requires=["composio_core===0.3.7"],
+    install_requires=["composio_core===0.3.8"],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="composio_core",
-    version="0.3.7",
+    version="0.3.8",
     author="Utkarsh",
     author_email="utkarsh@composio.dev",
     description="Core package to act as a bridge between composio platform and other services.",


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2920e4d975f16bf759fdab4d7b82f5c0db770292  | 
|--------|--------|

### Summary:
This PR enhances the `add_integration` function to handle case-insensitive app names and updates the `composio_core` version across various plugins.

**Key points**:
- Modified `name` parameter in `add_integration` call within `_add` function in `composio/cli/add.py` to be case-insensitive by applying `.lower().strip()`.
- Updated version of `composio_core` dependency to `0.3.8` in various plugins.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
