### PR TITLE
Add -h as shorthand for --help

### DIFF
--- a/composio/cli/__init__.py
+++ b/composio/cli/__init__.py
@@ -15,8 +15,11 @@ from composio.cli.triggers import _triggers
 from composio.cli.whoami import _whoami
 
 
-@click.group(name="composio")
+@click.group(name="composio", context_settings={'help_option_names': ['-h', '--help']})
 def composio() -> None:
+    """
+    Composio CLI Tool.
+    """
     """
     Composio CLI Tool.
     """


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `-h` as a shorthand for `--help` in the Composio CLI tool.
- Modified the `click.group` decorator to include `context_settings` with `help_option_names`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add `-h` shorthand for `--help` in CLI tool.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/cli/__init__.py

<li>Added <code>-h</code> as a shorthand for <code>--help</code> in the CLI tool.<br> <li> Modified the <code>click.group</code> decorator to include <code>context_settings</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/93/files#diff-8673a267670e10eac352c3a1cf5fcdbb1dd3c8f1ed12ebb9b5126b1836d45e36">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7ceef87716d6b2d509de7bb7b315066b3901b2e2  | 
|--------|--------|

### Summary:
This PR introduces `-h` as a shorthand for `--help` in the Composio CLI tool, enhancing user convenience.

**Key points**:
- Added `-h` as shorthand for `--help` in `composio/cli/__init__.py`.
- Modified `@click.group` decorator to include `context_settings={'help_option_names': ['-h', '--help']}`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
