### PR TITLE
Added fallback type string

### DIFF
--- a/composio/utils/shared.py
+++ b/composio/utils/shared.py
@@ -43,7 +43,9 @@ def json_schema_to_pydantic_type(
     :param json_schema: The JSON schema to convert.
     :return: A Pydantic type.
     """
-
+    # Add fallback type - string
+    if "type" not in json_schema:
+        json_schema["type"] = "string"
     type_ = t.cast(str, json_schema.get("type"))
     if type_ == "array":
         items_schema = json_schema.get("items")


### PR DESCRIPTION
### **User description**
Currecntly, if some scheme param does not contain `type`, it hits and exception, while point of the exception was to catch if we face any unsupported data type. 

So added a fix, if `type` key was not present,  added it as `"type": "string"`.


___

### **PR Type**
bug fix


___

### **Description**
- Added a fallback mechanism in `json_schema_to_pydantic_type` function to set the type as `string` if the `type` key is missing in the JSON schema.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shared.py</strong><dd><code>Add fallback type as string in JSON schema conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/utils/shared.py

<li>Added a fallback to set the type as <code>string</code> if the <code>type</code> key is missing <br>in the JSON schema.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/102/files#diff-6d20dc0b0bac4558837e344596d0615e26ff99f95592db858dcf8691cbe662e2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e7a040125795feb0ba5cb73753f0eb5e1f636fd4  | 
|--------|--------|

### Summary:
Implemented a fallback to 'string' type in `json_schema_to_pydantic_type` function within `composio/utils/shared.py` to handle missing 'type' keys in JSON schemas.

**Key points**:
- Added fallback to 'string' type in `json_schema_to_pydantic_type` function if 'type' key is missing.
- Modified `composio/utils/shared.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
