### PR TITLE
chore: show key instead of names in composio apps

### DIFF
--- a/composio/cli/apps.py
+++ b/composio/cli/apps.py
@@ -154,7 +154,7 @@ def _apps(context: Context, enabled: bool = False) -> None:
         else:
             context.console.print("[green]Showing all apps[/green]")
         for app in apps:
-            context.console.print(f"• {app.name}")
+            context.console.print(f"• {app.key}")
     except ComposioSDKError as e:
         raise click.ClickException(message=e.message) from e
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `composio/cli/apps.py` file to display app keys instead of app names in the console output.
- This change enhances the clarity and consistency of the information shown to the user.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apps.py</strong><dd><code>Display app keys instead of names in console output.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
composio/cli/apps.py

<li>Changed the display from app names to app keys in the console output.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SamparkAI/composio/pull/104/files#diff-af7c7b73e1a5accfee5d031170c9bf1cfb9776f61678afbee084fd423a303249">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 13e37f579ae03dcfa70dda2fb6bec6be1dcd1230  | 
|--------|--------|

### Summary:
Modified the app listing output in `composio/cli/apps.py` to show app keys instead of names.

**Key points**:
- Updated `_apps` function in `composio/cli/apps.py` to display `app.key` instead of `app.name`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
